### PR TITLE
Add a Breeding Code check

### DIFF
--- a/check-ebird-checklist.qmd
+++ b/check-ebird-checklist.qmd
@@ -104,7 +104,7 @@ obs <- obs_0 %>%
     "group_id", "checklist_id", "taxonomic_order", "common_name", "observation_count",
     "locality", "observation_date", "time_observations_started", "observer_id",
     "protocol_type", "duration_minutes", "effort_distance_km", "number_observers",
-    "all_species_reported", "has_media"))
+    "all_species_reported", "has_media", "breeding_code"))
 
 # Build checklist database
 c <- obs %>%
@@ -240,6 +240,8 @@ It is essential that you manually adapt the value of the parameters used here to
 
 -   `chk_specialized_protocol` (*Protocol Error*): You might want to check the use of non-standard protocols.
 
+-   `chk_invalid_breeding_code` (*Breeding Code*): You might want to check these out of Northern Hemisphere breeding codes.
+
 ```{r}
 chk <- c %>% 
   mutate(
@@ -258,7 +260,8 @@ chk <- c %>%
     chk_complete_media = all_species_reported & number_media==number_species,
     chk_not_stationary = protocol_type == "Stationary" & number_species>50,
     chk_specialized_protocol = !(protocol_type %in% c("Historical", "Traveling", "Incidental", "Stationary")),
-    chk_not_traveling = protocol_type=="Traveling" & effort_distance_km < 0.03
+    chk_not_traveling = protocol_type=="Traveling" & effort_distance_km < 0.03,
+    chk_invalid_breeding_code = nchar("breeding_code") > 1 & month(observation_date) %in% c(9, 10, 11, 12, 1, 2)
   ) %>% 
   mutate(across(starts_with("chk_"), ~replace_na(., FALSE)))
 

--- a/check_ebird_checklists/check_ebird_checklists_fcn.R
+++ b/check_ebird_checklists/check_ebird_checklists_fcn.R
@@ -28,7 +28,7 @@ create_chk <- function(txt_file, too_many_species, too_many_species_stationary, 
       "group_id", "checklist_id", "taxonomic_order", "common_name", "observation_count",
       "locality", "observation_date", "time_observations_started", "observer_id",
       "protocol_type", "duration_minutes", "effort_distance_km", "number_observers",
-      "all_species_reported", "has_media")) %>%
+      "all_species_reported", "has_media", "breeding_code")) %>%
     mutate(url = str_c("https://ebird.org/checklist/", str_extract(checklist_id, "[^,]+"), sep = "")) %>%
     relocate(url, .after = checklist_id)
 
@@ -72,7 +72,8 @@ create_chk <- function(txt_file, too_many_species, too_many_species_stationary, 
       complete_media = all_species_reported & number_media==number_species,
       not_stationary = protocol_type == "Stationary" & number_species > too_many_species_stationary,
       specialized_protocol = !(protocol_type %in% c("Historical", "Traveling", "Incidental", "Stationary")),
-      not_traveling = protocol_type=="Traveling" & effort_distance_km < 0.03
+      not_traveling = protocol_type=="Traveling" & effort_distance_km < 0.03,
+      invalid_breeding_code = nchar("breeding_code") > 1 & month(observation_date) %in% c(9, 10, 11, 12, 1, 2)
     )# %>%
     #mutate(across(starts_with("chk_"), ~replace_na(., FALSE)))
 

--- a/check_ebird_checklists/check_ebird_checklists_fcn.R
+++ b/check_ebird_checklists/check_ebird_checklists_fcn.R
@@ -12,7 +12,7 @@ library(writexl)
 library(glue)
 
 # Create function
-create_chk <- function(txt_file, too_many_species, too_many_species_stationary, too_long_distance, too_many_observers) {
+create_chk <- function(txt_file, hemisphere = "northern", too_many_species, too_many_species_stationary, too_long_distance, too_many_observers) {
 
   obs_0 <- read_ebd(txt_file)
 
@@ -55,6 +55,13 @@ create_chk <- function(txt_file, too_many_species, too_many_species_stationary, 
       all_species_reported = all_species_reported & protocol_type != "Incidental"
     )
 
+  # Define winter months based on hemisphere
+  if(tolower(hemisphere) == "southern") {
+    winter_months <- c(6, 7, 8, 9, 10, 11)  # Winter months for Southern Hemisphere
+  } else {
+    winter_months <- c(12, 1, 2, 3, 4, 5)  # Winter months for Northern Hemisphere
+  }
+
   chk <- c %>%
     mutate(
       ampm = (time_observations_started > hm("22:00") | time_observations_started < hm("4:00")) &
@@ -73,7 +80,7 @@ create_chk <- function(txt_file, too_many_species, too_many_species_stationary, 
       not_stationary = protocol_type == "Stationary" & number_species > too_many_species_stationary,
       specialized_protocol = !(protocol_type %in% c("Historical", "Traveling", "Incidental", "Stationary")),
       not_traveling = protocol_type=="Traveling" & effort_distance_km < 0.03,
-      invalid_breeding_code = nchar("breeding_code") > 1 & month(observation_date) %in% c(9, 10, 11, 12, 1, 2)
+      invalid_breeding_code = nchar("breeding_code") > 1 & month(observation_date) %in% winter_months
     )# %>%
     #mutate(across(starts_with("chk_"), ~replace_na(., FALSE)))
 


### PR DESCRIPTION
This check _should_ add a breeding code check, to see if there are nesting or juvenile breeding records during the northern or southern breeding months. Obviously, this won't apply to equatorial climates - perhaps it should be ignored if someone provides an `equatorial` parameter? 

This isn't tested. I'm having difficulty figuring out how to test and run R code without copying and pasting a ton of stuff from my editor into R.app. I feel like I need to go back and take some classes. 

Note: I think that we can update `devtools::install_github("RichardLitt/rebird@15608dfca8a3c9475254441798d304b26c136633")
` in ebird_api.R, too. 